### PR TITLE
adapt plugin to current obsidian api

### DIFF
--- a/src/CountdownTimer.ts
+++ b/src/CountdownTimer.ts
@@ -1,4 +1,4 @@
-import {Editor, Notice, WorkspaceLeaf} from "obsidian";
+import {Editor, MarkdownView, Notice, WorkspaceLeaf} from "obsidian";
 import DangerzoneWritingPlugin from "./main";
 
 export default class CountdownTimer {
@@ -10,16 +10,16 @@ export default class CountdownTimer {
     plugin: DangerzoneWritingPlugin;
     originalCountdownSeconds: number;
 
-    constructor(public counter: number, editor: Editor, statusBar: HTMLElement, activeLeaf: WorkspaceLeaf, secondsUntilDeletion: number, plugin: DangerzoneWritingPlugin) {
+    constructor(public counter: number, statusBar: HTMLElement, activeLeaf: WorkspaceLeaf, secondsUntilDeletion: number, plugin: DangerzoneWritingPlugin) {
         this.plugin = plugin;
-        this.editor = editor;
+        this.editor = (activeLeaf.view as MarkdownView).editor;
         this.secondsUntilDeletion = secondsUntilDeletion;
         this.secondsRemaining = secondsUntilDeletion;
         this.activeLeaf = activeLeaf;
         this.counter = counter;
         this.originalCountdownSeconds = counter;
 
-        const wrapper = (app.workspace.rootSplit as any).containerEl as HTMLElement;
+        const wrapper = activeLeaf.view.containerEl;
         const keyDownCb =  this.handleKeyDown.bind(this);
         wrapper.addEventListener("keydown", keyDownCb);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import {addIcon, Notice, Plugin, WorkspaceLeaf, MarkdownView} from 'obsidian';
+import {addIcon, Notice, Plugin, MarkdownView} from 'obsidian';
 import DangerzoneWritingPluginSettings from "./DangerzoneWritingPluginSettings";
 import DangerzoneWritingPluginSettingsTab from "./DangerzoneWritingPluginSettingsTab";
 import CountdownTimer from "./CountdownTimer";
@@ -20,12 +20,6 @@ export default class DangerzoneWritingPlugin extends Plugin {
         this.addRibbonIcon('watch', 'Dangerzone Writing', () => {
             this.startOrContinueTimer();
         });
-
-        this.registerEvent(
-            this.app.on("codemirror", (cm: CodeMirror.Editor) => {
-                cm.on("keydown", this.handleKeyDown);
-            })
-        );
 
         this.addCommand({
             id: "dangerzone-session-start",
@@ -77,17 +71,16 @@ export default class DangerzoneWritingPlugin extends Plugin {
         let activeLeaf = this.app.workspace.activeLeaf;
         const mdView = this.app.workspace.activeLeaf.view as MarkdownView;
 
-        if (mdView && mdView.sourceMode) {
-            const cmEditor = mdView.sourceMode.cmEditor;
+        if (mdView && mdView.getMode && mdView.getMode() === "source") {
+            const cmEditor = mdView.editor;
 
-            if (cmEditor) {
+            if (cmEditor && (app.workspace.rootSplit as any).containerEl as HTMLElement) {
                 this.countdown = new CountdownTimer(this.settings.getCountdownSecondsInteger(),
                     cmEditor,
                     this.statusBar,
                     activeLeaf,
                     this.settings.getSecondsUntilDeletionInteger(),
                     this);
-
                 new Notice("Dangerzone Writing session started!");
             } else {
                 new Notice("No editor active");
@@ -96,15 +89,6 @@ export default class DangerzoneWritingPlugin extends Plugin {
             new Notice("No file open.");
         }
     }
-
-    handleKeyDown = (
-        cm: CodeMirror.Editor,
-        event: KeyboardEvent
-    ): void => {
-        if (this.countdown && !this.countdown.isFinished()) {
-            this.countdown.resetSecondUntilDeletion();
-        }
-    };
 
     setCustomStyle() {
         const css = document.createElement('style');

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,15 +68,13 @@ export default class DangerzoneWritingPlugin extends Plugin {
     }
 
     startTimer() {
-        let activeLeaf = this.app.workspace.activeLeaf;
-        const mdView = this.app.workspace.activeLeaf.view as MarkdownView;
+        let activeLeaf = this.app.workspace.getLeaf();
 
-        if (mdView && mdView.getMode && mdView.getMode() === "source") {
-            const cmEditor = mdView.editor;
+        const mdView = activeLeaf.view as MarkdownView;
 
-            if (cmEditor && (app.workspace.rootSplit as any).containerEl as HTMLElement) {
+        if (mdView && mdView.getViewType() === "markdown" && mdView.getMode && mdView.getMode() === "source") {
+            if (mdView.editor) {
                 this.countdown = new CountdownTimer(this.settings.getCountdownSecondsInteger(),
-                    cmEditor,
                     this.statusBar,
                     activeLeaf,
                     this.settings.getSecondsUntilDeletionInteger(),


### PR DESCRIPTION
This PR makes the plugin work with the current obsidian API. 

The keydown event for the codemirror event ref was never fired, so I made a HTLMElement based workaround.
The rest I fixed via officially supported APIs. 